### PR TITLE
Add opencv-python to install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'tifffile>=2020.9.3',
         'docopt>=0.6.2',
         'logbook>=1.5.3',
+        'opencv-python>=4.0.0',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
### Motivation
- Ensure the `cv2` module is available by default by declaring OpenCV as an install requirement.

### Description
- Added `'opencv-python>=4.0.0'` to the `install_requires` list in `setup.py` so `cv2` is installed with the package.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ffa3d936c8333bc22700009b47451)