### PR TITLE
Lazy-load peak_analysis to avoid optional dependency errors and add OpenCV to install requirements

### DIFF
--- a/OSC_Reader/tools.py
+++ b/OSC_Reader/tools.py
@@ -12,7 +12,17 @@ from scipy.ndimage import rotate
 from scipy.optimize import curve_fit
 
 from .OSC_Reader import read_osc
-from . import peak_analysis as pa
+
+def _load_peak_analysis():
+    """Import peak_analysis only when needed."""
+    try:
+        from . import peak_analysis
+    except Exception as exc:
+        raise ImportError(
+            "The peak_analysis module is required for this operation. "
+            "Install optional dependencies such as lmfit to enable it."
+        ) from exc
+    return peak_analysis
 
 try:
     import datashader as ds
@@ -552,7 +562,8 @@ def plot_qz_vs_qr(
         [7, 12, -20, 20, "003"],
         [29, 32, 54, 66, "119"]
     ]
-    intensity, phi, theta, region_data = pa.process_data(
+    peak_analysis = _load_peak_analysis()
+    intensity, phi, theta, region_data = peak_analysis.process_data(
         ai,
         data,
         regions,

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'tifffile>=2020.9.3',
         'docopt>=0.6.2',
         'logbook>=1.5.3',
+        'opencv-python>=4.0.0',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
### Motivation
- Importing the package raised an `ImportError` when optional dependencies for `peak_analysis` (e.g. `lmfit`) were not installed, which made unrelated top-level imports fail. 
- Ensure `cv2` is available when the package is installed by declaring OpenCV as an install requirement.

### Description
- Add a helper function `_load_peak_analysis()` that imports `peak_analysis` on demand and raises a clear `ImportError` instructing users to install optional deps (for example `lmfit`).
- Replace the module-level `peak_analysis` import with a call to `_load_peak_analysis()` before invoking `process_data()` so optional features are only loaded when needed.
- Add `'opencv-python>=4.0.0'` to `install_requires` in `setup.py` so the `cv2` module is installed with the package.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ffa3d936c8333bc22700009b47451)