### PR TITLE
Defer lmfit imports and lazy-load peak_analysis; add OpenCV to requirements

### DIFF
--- a/OSC_Reader/peak_analysis.py
+++ b/OSC_Reader/peak_analysis.py
@@ -2,16 +2,31 @@
 
 import numpy as np
 import matplotlib.pyplot as plt
-from lmfit.models import (
-    GaussianModel,
-    LorentzianModel,
-    LinearModel,
-    ConstantModel,
-    PseudoVoigtModel,
-    PolynomialModel,
-)
-from lmfit.lineshapes import gaussian, lorentzian
 import matplotlib.gridspec as gridspec
+
+
+def _load_lmfit_models():
+    from lmfit.models import (
+        GaussianModel,
+        LorentzianModel,
+        LinearModel,
+        ConstantModel,
+        PseudoVoigtModel,
+        PolynomialModel,
+    )
+    return {
+        "GaussianModel": GaussianModel,
+        "LorentzianModel": LorentzianModel,
+        "LinearModel": LinearModel,
+        "ConstantModel": ConstantModel,
+        "PseudoVoigtModel": PseudoVoigtModel,
+        "PolynomialModel": PolynomialModel,
+    }
+
+
+def _load_lmfit_lineshapes():
+    from lmfit.lineshapes import gaussian, lorentzian
+    return gaussian, lorentzian
 
 ##############################################################################
 # 1) Helper functions
@@ -126,6 +141,11 @@ def perform_fit(x, y, lower_bound, upper_bound, equal_weight_fit=False):
     if y.size == 0 or not np.any(y > 0):
         return None
 
+    models = _load_lmfit_models()
+    GaussianModel = models["GaussianModel"]
+    LorentzianModel = models["LorentzianModel"]
+    LinearModel = models["LinearModel"]
+
     amp, cen, sigma = estimate_initial_parameters(x, y)
 
     gauss = GaussianModel(prefix='g_')
@@ -171,6 +191,8 @@ def plot_fit_with_components(ax_obj, x_data, y_data, fit_result, x_label, use_lo
     ax_obj.plot(x_data, y_data, 'ko', label='Raw Data', markersize=4, zorder=1)
     x_smooth = np.linspace(x_data.min(), x_data.max(), 300)
     y_fit_total = fit_result.eval(x=x_smooth)
+
+    gaussian, lorentzian = _load_lmfit_lineshapes()
     
     # Extract parameters from the fit result
     g_amp = fit_result.params['g_amplitude'].value
@@ -307,6 +329,12 @@ def fit_pvoigt_peaks(
             mask &= qz <= end
         qz = qz[mask]
         intensity = intensity[mask]
+
+    models = _load_lmfit_models()
+    PolynomialModel = models["PolynomialModel"]
+    LinearModel = models["LinearModel"]
+    ConstantModel = models["ConstantModel"]
+    PseudoVoigtModel = models["PseudoVoigtModel"]
 
     if background_type == "polynomial":
         background = PolynomialModel(background_degree, prefix="bkg_")

--- a/OSC_Reader/tools.py
+++ b/OSC_Reader/tools.py
@@ -12,7 +12,11 @@ from scipy.ndimage import rotate
 from scipy.optimize import curve_fit
 
 from .OSC_Reader import read_osc
-from . import peak_analysis as pa
+
+def _load_peak_analysis():
+    """Import peak_analysis only when needed."""
+    from . import peak_analysis
+    return peak_analysis
 
 try:
     import datashader as ds
@@ -552,7 +556,8 @@ def plot_qz_vs_qr(
         [7, 12, -20, 20, "003"],
         [29, 32, 54, 66, "119"]
     ]
-    intensity, phi, theta, region_data = pa.process_data(
+    peak_analysis = _load_peak_analysis()
+    intensity, phi, theta, region_data = peak_analysis.process_data(
         ai,
         data,
         regions,

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         'tifffile>=2020.9.3',
         'docopt>=0.6.2',
         'logbook>=1.5.3',
+        'opencv-python>=4.0.0',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
### Motivation
- Importing the package previously failed with `ModuleNotFoundError` when optional dependencies for peak fitting (`lmfit`) were not installed, which blocked unrelated utilities.
- Reduce eager imports so optional functionality is only loaded when needed and ensure `cv2` is present when the package is installed.

### Description
- Add lazy loaders ` _load_lmfit_models()` and `_load_lmfit_lineshapes()` in `OSC_Reader/peak_analysis.py` and call them from `perform_fit`, `plot_fit_with_components`, and `fit_pvoigt_peaks` so `lmfit` is imported on demand.
- Replace the module-level `peak_analysis` import in `OSC_Reader/tools.py` with a helper ` _load_peak_analysis()` and update call sites to load the module before invoking `process_data`.
- Add `'opencv-python>=4.0.0'` to `install_requires` in `setup.py` so the `cv2` module is installed with the package.
- Simplify ` _load_peak_analysis()` to perform an on-demand import and return the `peak_analysis` module.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ffa3d936c8333bc22700009b47451)